### PR TITLE
Add hours back to Bragtown

### DIFF
--- a/data/libraries.yml
+++ b/data/libraries.yml
@@ -85,11 +85,11 @@ warren:
 bragtown:
   name: Bragtown Library Family Literacy Center
   hours:
-    Monday: []
-    Tuesday: []
-    Wednesday: []
-    Thursday: []
-    Friday: []
+    Monday: ['1400', '1800']
+    Tuesday: ['1400', '1800']
+    Wednesday: ['1400', '1800']
+    Thursday: ['1400', '1800']
+    Friday: ['1400', '1800']
     Saturday: []
     Sunday: []
   address:


### PR DESCRIPTION
Bragtown Library has reopened. Added hours back to its entry.